### PR TITLE
change matplotlib backend for mac

### DIFF
--- a/imjoy-plugins/NuclearEnvelopeDistance.imjoy.html
+++ b/imjoy-plugins/NuclearEnvelopeDistance.imjoy.html
@@ -42,6 +42,10 @@ import json
 import copy
 import numpy as np
 
+if sys.platform == "darwin":
+    import matplotlib
+    matplotlib.use('PS')
+ 
 from rnaloc import LOCtoolbox
 
 class ImJoyPlugin():


### PR DESCRIPTION
I got this error:
```
Traceback (most recent call last): File "/anaconda/lib/python3.6/site-packages/imjoy/workers/python_client.py", line 76, in handle_execute exec(content, conn.local) # pylint: disable=exec-used 
File "<string>", line 14, in <module> 
File "/anaconda/lib/python3.6/site-packages/rnaloc/LOCtoolbox.py", line 13, in <module> import matplotlib.pyplot as plt File "/anaconda/lib/python3.6/site-packages/matplotlib/pyplot.py", line 116, in <module> _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup() 
File "/anaconda/lib/python3.6/site-packages/matplotlib/backends/__init__.py", line 60, in pylab_setup [backend_name], 0) 
File "/anaconda/lib/python3.6/site-packages/matplotlib/backends/backend_macosx.py", line 17, in <module> f

rom matplotlib.backends import _macosx RuntimeError: Python is not installed as a framework. The Mac OS X backend will not be able to function correctly if Python is not installed as a framework. See the Python documentation for more information on installing Python as a framework on Mac OS X. Please either reinstall Python as a framework, or try one of the other backends. If you are using (Ana)Conda please install python.app and replace the use of 'python' with 'pythonw'. See 'Working with Matplotlib on OSX' in the Matplotlib FAQ for more information.
```

This fixes the problem for me, please test.