### PR TITLE
add -U for pip install

### DIFF
--- a/imjoy-plugins/NuclearEnvelopeDistance.imjoy.html
+++ b/imjoy-plugins/NuclearEnvelopeDistance.imjoy.html
@@ -6,7 +6,7 @@
 {
   "name": "NuclearEnvelopeDistance",
   "type": "native-python",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Plugin to analyze enrichment of RNAs relative to cell membranes.",
   "tags": ["stable","dev"],
   "ui": [
@@ -22,9 +22,9 @@
   "icon": "border_outer",
   "api_version": "0.1.5",
   "env": "conda create -n rna-memb-dist python=3.6",
-  "requirements": { "stable":["git+https://github.com/muellerflorian/rna-loc@860197d#egg=rnaloc","scikit-image", "read-roi", "nested-lookup"],
-                    "dev": ["scikit-image", "read-roi", "nested-lookup",
-                            "pip:  --editable /Volumes/PILON_HD2/fmueller/Documents/code/ImJoy/rna-loc"]},
+  "requirements": { "stable":["pip: -U git+https://github.com/muellerflorian/rna-loc@860197d#egg=rnaloc","pip: scikit-image read-roi nested-lookup"],
+                    "dev": ["pip: scikit-image read-roi nested-lookup",
+                            "pip: --editable /Volumes/PILON_HD2/fmueller/Documents/code/ImJoy/rna-loc"]},
   "dependencies": ["muellerflorian/rna-loc:MembraneDistProgress"]
 }
 </config>


### PR DESCRIPTION
This will force pip to install from the commit hash tag.

Also add `pip:` prefix before all the pip packages.